### PR TITLE
pa6 update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ mkfs
 kernel/kernel
 user/usys.S
 .gdbinit
+out/

--- a/Makefile
+++ b/Makefile
@@ -200,7 +200,10 @@ qemu-verbose: $K/kernel fs.img
 	echo "$(QEMU) $(QEMUOPTS)"
 	$(QEMU) $(QEMUOPTS)
 
-test: $K/kernel fs.img run-test.py
+out:
+	@mkdir $@
+
+test: run-test.py out $K/kernel fs.img
 	@./run-test.py
 #---------------------------------------------------------
 

--- a/ans/kthtest0.ans
+++ b/ans/kthtest0.ans
@@ -11,4 +11,3 @@ running test_hello
 $ QEMU: Terminated
 
 
-

--- a/ans/kthtest1.ans
+++ b/ans/kthtest1.ans
@@ -12,4 +12,3 @@ running test_arg
 $ QEMU: Terminated
 
 
-

--- a/ans/kthtest2.ans
+++ b/ans/kthtest2.ans
@@ -22,4 +22,3 @@ running test_create
 $ QEMU: Terminated
 
 
-

--- a/ans/kthtest3.ans
+++ b/ans/kthtest3.ans
@@ -34,4 +34,3 @@ running test_rr
 $ QEMU: Terminated
 
 
-

--- a/ans/kthtest4.ans
+++ b/ans/kthtest4.ans
@@ -16,4 +16,3 @@ running test_lower
 $ QEMU: Terminated
 
 
-

--- a/ans/kthtest5.ans
+++ b/ans/kthtest5.ans
@@ -32,4 +32,3 @@ running test_donate
 $ QEMU: Terminated
 
 
-

--- a/ans/kthtest6.ans
+++ b/ans/kthtest6.ans
@@ -55,4 +55,3 @@ running test_donate_simple
 $ QEMU: Terminated
 
 
-

--- a/ans/kthtest7.ans
+++ b/ans/kthtest7.ans
@@ -36,4 +36,3 @@ running test_donate_multiple
 $ QEMU: Terminated
 
 
-

--- a/ans/kthtest8.ans
+++ b/ans/kthtest8.ans
@@ -41,4 +41,3 @@ running test_donate_multiple2
 $ QEMU: Terminated
 
 
-

--- a/ans/kthtest9.ans
+++ b/ans/kthtest9.ans
@@ -41,4 +41,3 @@ running test_donate_nest
 $ QEMU: Terminated
 
 
-

--- a/compare
+++ b/compare
@@ -1,0 +1,26 @@
+#!/bin/bash
+#---------------------------------------------------------------------
+#
+#  4190.307: Operating Systems (Spring 2020)
+#
+#  PA#6: Utility script for test result compare
+#
+#  June 2, 2020
+#
+#  Yeon-Gyu Jeong
+#  Systems Software and Architecture Laboratory
+#  Department of Computer Science and Engineering
+#  Seoul National University
+#
+#---------------------------------------------------------------------
+
+readonly NUM_TEST=10
+
+if [ "${1}" == "" ] || [ ${1} -lt 0 ] || [ ${1} -ge ${NUM_TEST} ]; then
+  echo "Invalid argument."
+  echo "  Usage: ${0} [test_number]"
+  echo "  [test_number] must be in range [0, ${NUM_TEST})"
+  exit 1
+else
+  diff --side-by-side "out/kthtest${1}.out" "ans/kthtest${1}.ans"
+fi

--- a/run-test.py
+++ b/run-test.py
@@ -24,37 +24,45 @@ from subprocess import *
 
 def test_i(i):
   print("Test %d ... " % i, end="", flush=True)
-  qemu = Popen(["make", "-s", "qemu-verbose"], 
+  qemu = Popen(["make", "-s", "qemu-verbose"],
       stdin=PIPE, stdout=PIPE, stderr=PIPE,
       universal_newlines=True, preexec_fn=os.setsid)
+  qemu_killed = False
 
-  time.sleep(1)
-  qemu.stdin.write("kthtest %d\n" % i)
-  qemu.stdin.flush()
-  time.sleep(5)
-  qemu.stdin.write("\x01x");
-  qemu.stdin.flush()
-
-  results = tuple()
   try:
-    results = qemu.communicate(timeout=10)
-  except TimeoutExpired:
-    os.killpg(os.getpgid(qemu.pid), signal.SIGTERM)
-    results = qemu.communicate()
+    time.sleep(1)
+    qemu.stdin.write("kthtest %d\n" % i)
+    qemu.stdin.flush()
+    time.sleep(5)
+    qemu.stdin.write("\x01x");
+    qemu.stdin.flush()
 
-  out_path = Path("./out/kthtest%d.out" % i)
-  with out_path.open("wt") as outfd:
-    print(results[0], file=outfd)
-    print(results[1], file=outfd)
+    results = tuple()
+    try:
+      results = qemu.communicate(timeout=10)
+    except TimeoutExpired:
+      os.killpg(os.getpgid(qemu.pid), signal.SIGTERM)
+      results = qemu.communicate()
+    qemu_killed = True
 
-  
-for i in range(10):
-  test_i(i)
-  and_file = "./ans/kthtest%d.ans" % i
-  out_file = "./out/kthtest%d.out" % i
-  rc = os.system("cmp -s " + and_file + " " + out_file)
-  if rc == 0:
-    print("PASS")
-  else:
-    print("FAIL")
+    out_path = Path("./out/kthtest%d.out" % i)
+    with out_path.open("wt") as outfd:
+      print(results[0], file=outfd)
 
+  finally:
+    if not qemu_killed:
+      os.killpg(os.getpgid(qemu.pid), signal.SIGTERM)
+
+
+try:
+  for i in range(10):
+    test_i(i)
+    and_file = "./ans/kthtest%d.ans" % i
+    out_file = "./out/kthtest%d.out" % i
+    rc = os.system("cmp -s " + and_file + " " + out_file)
+    if rc == 0:
+      print("PASS")
+    else:
+      print("FAIL")
+except KeyboardInterrupt:
+  pass


### PR DESCRIPTION
 Updated test environment

* Not printing stderr to out file
  * To prevent make warning when -j flag is used
* Make out directory, kernel, and fs.img as dependency on make test
  * To prevent make messages be written to out file
* Kill qemu process when ^c is pressed on run-test.py
* Added out directory to .gitignore
* Added result comparing utility